### PR TITLE
Fixes undefined variable error

### DIFF
--- a/mbox-to-json.js
+++ b/mbox-to-json.js
@@ -13,11 +13,12 @@ function main() {
 	var messages = [];
 	var total = Infinity;
 	var mbox = new Mbox();
+	var messageCount = 0;
 	mbox.on('message', function(msg) {
 	  // parse message using MailParser
 	  var mailparser = new MailParser({ streamAttachments : true });
 	  mailparser.on('end', function(mail) {
-	  	messages.push(mail);
+		  messages.push(mail);
 	  	if (messages.length == messageCount) {
 	  		console.log('Finished parsing messages');
 	  		if (argv.o)


### PR DESCRIPTION
fixes error below
```
/home/moe/Desktop/repos/mbox-to-json/mbox-to-json.js:22
	  	if (messages.length == messageCount) {
	  	                       ^

ReferenceError: messageCount is not defined
    at MailParser.<anonymous> (/home/moe/Desktop/repos/mbox-to-json/mbox-to-json.js:22:28)
    at emitOne (events.js:116:13)
    at MailParser.emit (events.js:211:7)
    at runCallback (timers.js:789:20)
    at tryOnImmediate (timers.js:751:5)
    at processImmediate [as _immediateCallback] (timers.js:722:5)
```
This is a simple fix i assume this is due to me using a higher version of node which probably doesn't allow these kind of operations anymore
  